### PR TITLE
Zastapienie uzycia FitnessActivities.getName()

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="com.fitatu.phonegap.plugin.googlefit"
-        version="0.0.6">
+        version="0.0.7">
 
     <name>Google Fit phonegap plugin</name>
     <description>Google Fit phonegap plugin</description>

--- a/src/android/GoogleFitService.java
+++ b/src/android/GoogleFitService.java
@@ -13,12 +13,12 @@ import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.fitness.Fitness;
-import com.google.android.gms.fitness.FitnessActivities;
 import com.google.android.gms.fitness.data.Bucket;
 import com.google.android.gms.fitness.data.DataPoint;
 import com.google.android.gms.fitness.data.DataSet;
 import com.google.android.gms.fitness.data.DataType;
 import com.google.android.gms.fitness.data.Field;
+import com.google.android.gms.fitness.data.Value;
 import com.google.android.gms.fitness.request.DataReadRequest;
 import com.google.android.gms.fitness.result.DataReadResult;
 
@@ -167,9 +167,10 @@ public class GoogleFitService {
                         } else if (field.getName().equals("distance")) {
                             activity.setDistance(dp.getValue(field).asFloat());
                         } else if (field.getName().equals("activity")) {
-                            int activityType = dp.getValue(field).asInt();
+                            Value value = dp.getValue(field);
+                            int activityType = value.asInt();
                             activity.setTypeId(activityType);
-                            activity.setName(FitnessActivities.getName(activityType));
+                            activity.setName(value.asActivity());
                         }
                     }
                 }


### PR DESCRIPTION
Zastąpienie niewspieranej w nowych wersjach google fitness api metody FitnessActivities.getName()

Error: 
/project/src/com/fitatu/phonegap/plugin/GoogleFit/GoogleFitService.java:172: 
error: cannot find symbol activity.setName(FitnessActivities.getName(activityType));